### PR TITLE
Optimize the sliding display effect of module page

### DIFF
--- a/app/src/main/kotlin/com/dergoogler/mmrl/ui/screens/modules/ModuleItem.kt
+++ b/app/src/main/kotlin/com/dergoogler/mmrl/ui/screens/modules/ModuleItem.kt
@@ -89,6 +89,12 @@ fun ModuleItem(
     trailingButton: @Composable() (RowScope.() -> Unit),
     isBlacklisted: Boolean = false,
     isProviderAlive: Boolean,
+    cachedDisplayName: String? = null,
+    cachedVersionAuthor: String? = null,
+    cachedUpdateTime: String? = null,
+    cachedDescription: AnnotatedString? = null,
+    cachedFormattedSize: String? = null,
+    isWebUIPackageInstalled: Boolean = false,
 ) {
     val userPreferences = LocalUserPreferences.current
     val menu = userPreferences.modulesMenu
@@ -100,7 +106,7 @@ fun ModuleItem(
         isProviderAlive && module.hasWebUI && module.state != State.REMOVE
 
     val clicker: (() -> Unit)? = canWenUIAccessed nullable jump@{
-        if (!context.isPackageInstalled(WebUIXPackageName)) {
+        if (!isWebUIPackageInstalled) {
             requiredAppBottomSheet = true
             return@jump
         }
@@ -163,13 +169,13 @@ fun ModuleItem(
                     verticalArrangement = Arrangement.spacedBy(2.dp)
                 ) {
                     TextWithIcon(
-                        text = module.config.name ?: module.name,
+                        text = cachedDisplayName ?: (module.config.name ?: module.name),
                         icon = canWenUIAccessed nullable R.drawable.sandbox,
                         style = TextWithIconDefaults.style.copy(textStyle = MaterialTheme.typography.titleSmall)
                     )
 
                     Text(
-                        text = stringResource(
+                        text = cachedVersionAuthor ?: stringResource(
                             id = R.string.module_version_author,
                             module.versionDisplay, module.author
                         ),
@@ -180,7 +186,7 @@ fun ModuleItem(
 
                     if (module.lastUpdated != 0L && menu.showUpdatedTime) {
                         Text(
-                            text = stringResource(
+                            text = cachedUpdateTime ?: stringResource(
                                 id = R.string.module_update_at,
                                 module.lastUpdated.toFormattedDateSafely
                             ),
@@ -194,7 +200,7 @@ fun ModuleItem(
                 switch?.invoke()
             }
 
-            val description = if (module.config.description != null) {
+            val description = cachedDescription ?: if (module.config.description != null) {
                 module.config.description!!.toStyleMarkup()
             } else {
                 AnnotatedString(module.description)
@@ -227,7 +233,7 @@ fun ModuleItem(
                 }
 
                 LabelItem(
-                    text = module.size.toFormattedFileSize(),
+                    text = cachedFormattedSize ?: module.size.toFormattedFileSize(),
                     style = LabelItemDefaults.style.copy(
                         containerColor = MaterialTheme.colorScheme.secondaryContainer,
                         contentColor = MaterialTheme.colorScheme.onSecondaryContainer

--- a/app/src/main/kotlin/com/dergoogler/mmrl/ui/screens/modules/ModulesList.kt
+++ b/app/src/main/kotlin/com/dergoogler/mmrl/ui/screens/modules/ModulesList.kt
@@ -52,12 +52,21 @@ import com.dergoogler.mmrl.webui.model.WebUIConfig
 import com.dergoogler.mmrl.webui.model.WebUIConfig.Companion.webUiConfig
 import dev.dergoogler.mmrl.compat.core.LocalUriHandler
 
+data class ModuleCacheData(
+    val displayName: String,
+    val versionAuthor: String,
+    val updateTime: String?,
+    val formattedSize: String,
+    val isWebUIPackageInstalled: Boolean
+)
+
 @Composable
 fun ScaffoldScope.ModulesList(
     list: List<LocalModule>,
     state: LazyListState,
     onDownload: (LocalModule, VersionItem, Boolean) -> Unit,
     viewModel: ModulesViewModel,
+    cachedModuleData: Map<String, ModuleCacheData> = emptyMap(),
 ) = Box(
     modifier = Modifier.fillMaxSize()
 ) {
@@ -76,6 +85,7 @@ fun ScaffoldScope.ModulesList(
                     module = module,
                     viewModel = viewModel,
                     onDownload = onDownload,
+                    cachedData = cachedModuleData[module.id.toString()]
                 )
             }
         }
@@ -92,6 +102,7 @@ fun ModuleItem(
     module: LocalModule,
     onDownload: (LocalModule, VersionItem, Boolean) -> Unit,
     viewModel: ModulesViewModel,
+    cachedData: ModuleCacheData? = null,
 ) {
     val userPreferences = LocalUserPreferences.current
 
@@ -189,8 +200,12 @@ fun ModuleItem(
                 enabled = isProviderAlive && (!(viewModel.moduleCompatibility.canRestoreModules && userPreferences.useShellForModuleStateChange) || module.state != State.REMOVE),
                 onClick = ops.change
             )
-
-        }
+        },
+        cachedDisplayName = cachedData?.displayName,
+        cachedVersionAuthor = cachedData?.versionAuthor,
+        cachedUpdateTime = cachedData?.updateTime,
+        cachedFormattedSize = cachedData?.formattedSize,
+        isWebUIPackageInstalled = cachedData?.isWebUIPackageInstalled ?: false
     )
 }
 

--- a/app/src/main/kotlin/com/dergoogler/mmrl/ui/screens/modules/ModulesMenu.kt
+++ b/app/src/main/kotlin/com/dergoogler/mmrl/ui/screens/modules/ModulesMenu.kt
@@ -39,10 +39,12 @@ import com.dergoogler.mmrl.ext.shareText
 import com.dergoogler.mmrl.ext.toFormattedDateSafely
 import com.dergoogler.mmrl.platform.PlatformManager
 import com.dergoogler.mmrl.platform.file.SuFile.Companion.toFormattedFileSize
+import com.dergoogler.mmrl.model.local.LocalModule
 
 @Composable
 fun ModulesMenu(
     setMenu: (ModulesMenu) -> Unit,
+    cachedModules: List<LocalModule> = emptyList(),
 ) {
     val userPreferences = LocalUserPreferences.current
     var open by rememberSaveable { mutableStateOf(false) }
@@ -59,7 +61,8 @@ fun ModulesMenu(
             MenuBottomSheet(
                 onClose = { open = false },
                 menu = userPreferences.modulesMenu,
-                setMenu = setMenu
+                setMenu = setMenu,
+                cachedModules = cachedModules
             )
         }
     }
@@ -70,6 +73,7 @@ private fun MenuBottomSheet(
     onClose: () -> Unit,
     menu: ModulesMenu,
     setMenu: (ModulesMenu) -> Unit,
+    cachedModules: List<LocalModule>,
 ) = BottomSheet(onDismissRequest = onClose) {
     val options = listOf(
         Option.Name to R.string.menu_sort_option_name,
@@ -161,18 +165,18 @@ private fun MenuBottomSheet(
         Spacer(modifier = Modifier.height(16.dp))
 
         OutlinedButton(
-            enabled = PlatformManager.isAlive,
+            enabled = cachedModules.isNotEmpty(),
             onClick = {
                 val builder = StringBuilder()
 
                 with(builder) {
-                    PlatformManager.moduleManager.modules.map {
-                        append("Name: ${it.name}\n")
-                        append("ID: ${it.id}\n")
-                        append("Version: ${it.version}\n")
-                        append("VersionCode: ${it.versionCode}\n")
-                        append("Stat: ${it.lastUpdated.toFormattedDateSafely()}\n")
-                        append("Size: ${it.size.toFormattedFileSize()}\n\n")
+                    cachedModules.map { module ->
+                        append("Name: ${module.name}\n")
+                        append("ID: ${module.id}\n")
+                        append("Version: ${module.version}\n")
+                        append("VersionCode: ${module.versionCode}\n")
+                        append("Stat: ${module.lastUpdated.toFormattedDateSafely()}\n")
+                        append("Size: ${module.size.toFormattedFileSize()}\n\n")
                     }
                 }
 


### PR DESCRIPTION
I found it a bit visually disruptive due to the constant refreshing, so refresh only once each time you go to the module page, otherwise use the cache


You can also take the initiative to make changes if the program I provide is incorrect