### PR TITLE
Fix AAB

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -93,7 +93,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           validate-wrappers: true
-          cache-cleanup: true
 
       - name: Bundle with Gradle
         run: chmod +x ./gradlew && ./gradlew bundleOfficialPlaystore
@@ -113,3 +112,4 @@ jobs:
           track: production
           status: completed
           inAppUpdatePriority: 5
+

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Find AAB
         id: find_aab
         run: |
-          AAB_PATH=$(find app/build/outputs/bundle/releasePlaystore -name "*.aab" -print -quit)
+          AAB_PATH=$(find app/build/outputs/bundle/official/playstore -name "*.aab" -print -quit)
           echo "AAB_PATH=$AAB_PATH" >> $GITHUB_OUTPUT
 
       - name: Upload to Google Play
@@ -112,6 +112,7 @@ jobs:
           track: production
           status: completed
           inAppUpdatePriority: 5
+
 
 
 

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Find AAB
         id: find_aab
         run: |
-          AAB_PATH=$(find app/build/outputs/bundle/release/playstore -name "*.aab" -print -quit)
+          AAB_PATH=$(find app/build/outputs/bundle/releasePlaystore -name "*.aab" -print -quit)
           echo "AAB_PATH=$AAB_PATH" >> $GITHUB_OUTPUT
 
       - name: Upload to Google Play
@@ -112,5 +112,6 @@ jobs:
           track: production
           status: completed
           inAppUpdatePriority: 5
+
 
 

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Find AAB
         id: find_aab
         run: |
-          AAB_PATH=$(find app/build/outputs/bundle/playstore -name "*.aab" -print -quit)
+          AAB_PATH=$(find app/build/outputs/bundle/release/playstore -name "*.aab" -print -quit)
           echo "AAB_PATH=$AAB_PATH" >> $GITHUB_OUTPUT
 
       - name: Upload to Google Play
@@ -112,4 +112,5 @@ jobs:
           track: production
           status: completed
           inAppUpdatePriority: 5
+
 

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Find AAB
         id: find_aab
         run: |
-          AAB_PATH=$(find app/build/outputs/bundle/official/playstore -name "*.aab" -print -quit)
+          AAB_PATH=$(find app/build/outputs/bundle/officialPlaystore -name "*.aab" -print -quit)
           echo "AAB_PATH=$AAB_PATH" >> $GITHUB_OUTPUT
 
       - name: Upload to Google Play
@@ -112,6 +112,7 @@ jobs:
           track: production
           status: completed
           inAppUpdatePriority: 5
+
 
 
 


### PR DESCRIPTION
This pull request makes a minor update to the release CI workflow to ensure the correct Android App Bundle (AAB) is located during the release process.

* Updated the path in the `find_aab` step to search for the AAB in the `officialPlaystore` output directory instead of the `playstore` directory, ensuring the correct bundle is used for release.