### PR TITLE
Skip URL filter for subresources and avoid double-load of allow-list URLs in module description WebView

### DIFF
--- a/app/src/main/kotlin/com/dergoogler/mmrl/ui/screens/moduleView/ViewDescriptionScreen.kt
+++ b/app/src/main/kotlin/com/dergoogler/mmrl/ui/screens/moduleView/ViewDescriptionScreen.kt
@@ -164,6 +164,10 @@ fun ViewDescriptionScreen(readmeUrl: String) =
                                             view: WebView,
                                             request: WebResourceRequest,
                                         ): Boolean {
+                                            if (!request.isForMainFrame) {
+                                                return false
+                                            }
+
                                             val mUri = request.url ?: return false
                                             val mUrl = mUri.toString()
 
@@ -179,7 +183,6 @@ fun ViewDescriptionScreen(readmeUrl: String) =
                                                 return true
                                             }
 
-                                            view.loadUrl(mUrl)
                                             return false
                                         }
 


### PR DESCRIPTION
### What this does

Two small fixes in the `WebViewClient` used to render module descriptions in `app/src/main/kotlin/com/dergoogler/mmrl/ui/screens/moduleView/ViewDescriptionScreen.kt`:

1. Add `if (!request.isForMainFrame) return false` at the top of `shouldOverrideUrlLoading` so the dispatcher only acts on top-level navigations.
2. Drop the redundant `view.loadUrl(mUrl)` call before the final `return false`.

### Why

For an allow-list URL the previous flow was `view.loadUrl(mUrl)` followed by `return false`. Returning false already tells the WebView to load the URL itself, so the explicit `loadUrl` causes the page to be fetched twice on any in-page link click to a `desc.mmrl.dev` URL.

For the subresource path, `shouldOverrideUrlLoading` is dispatched for iframe navigations and some redirect flows. Without the `isForMainFrame` gate, an off-allow-list subresource (for example an embedded frame) would get routed into `Intent.ACTION_VIEW`, which is not what the comment above the WebView (`// #NotAReadlDomain`) intends.

### Diff size

Four lines added, one removed, all inside the existing `shouldOverrideUrlLoading` override. No public API changes.